### PR TITLE
Add enable call to node exporter post, remove $ in CLI example

### DIFF
--- a/content/blog/linux-node-exporter-setup.md
+++ b/content/blog/linux-node-exporter-setup.md
@@ -57,7 +57,7 @@ WantedBy=multi-user.target
 EOF'
 ```
 
-We now perform a reload, start and enable the process. The `enable` call will ensure it will start at boot:
+We now perform a reload, start and enable the process. The enable call will ensure it will start at boot:
 ```shell
 sudo systemctl daemon-reload
 sudo systemctl start node_exporter

--- a/content/blog/linux-node-exporter-setup.md
+++ b/content/blog/linux-node-exporter-setup.md
@@ -57,15 +57,16 @@ WantedBy=multi-user.target
 EOF'
 ```
 
-We now perform a reload and start the process.
+We now perform a reload, start and enable the process. The `enable` call will ensure it will start at boot:
 ```shell
 sudo systemctl daemon-reload
 sudo systemctl start node_exporter
+sudo systemctl enable node_exporter
 ```
 
 We can then check to see if process is running properly.
 ```shell
-$ sudo systemctl status node_exporter
+sudo systemctl status node_exporter
 ● node_exporter.service - Node Exporter
    Loaded: loaded (/etc/systemd/system/node_exporter.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2021-08-19 14:38:14 +08; 23h ago


### PR DESCRIPTION
HI @jaanhio  - Love this post - so helpful and so concise - thank you!

However, I noticed that when testing the `systemctl` calls that node exporter wasn't starting on boot.  Then I saw that while you had a `start` call, you didn't have an `enable` call.  This PR fixes that.

As well, when I copied a line from from one of your shell outputs, I accidentally grabbed the `$` there.  While handy to denote this is a command line call, since we can't use the [CSS `user-select`](https://www.w3schools.com/howto/howto_css_disable_text_selection.asp) to disable selections, I propose just removing it.